### PR TITLE
Fix link to l2kurz

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Die Dokumentation unterliegt der Open Publication License (V1.0 oder höher), si
 Das Projekt ruht derzeit im dem Sinne, dass wir nur noch Tippfehler korrigieren.
 Jeder ist willkommen, Änderungen beizusteuern.
 
-Generiertes PDF: [l2kurz.pdf](l2kurz.pdf) <!-- funktoiniert nur auf https://dante-ev.github.io/l2kurz/ -->
+Generiertes PDF: <https://dante-ev.github.io/l2kurz/l2kurz.pdf>.
 
 ## Interessante LaTeX-Links
 


### PR DESCRIPTION
My HTML comment was hidden very well and lead to a wrong link in #11. Thus, replacing the relative link by an absolute one.