### PR TITLE
Readme: fix SPDX-License-Identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ Generiertes PDF: <https://dante-ev.github.io/l2kurz/l2kurz.pdf>.
 
 ## Lizenz
 
-SPDX-License-Identifier: OPL-1.0+
+SPDX-License-Identifier: OPUBL-1.0+


### PR DESCRIPTION
The SPDX identifier of the [Open Publication License](https://spdx.org/licenses/OPUBL-1.0.html) is OPUBL-1.0. 

OPL-1.0 is the [Open Public License](https://spdx.org/licenses/OPL-1.0.html), which is a different license.