### PR TITLE
Update textsatz.tex. Replace "i\`eme" by "e"

### DIFF
--- a/textsatz.tex
+++ b/textsatz.tex
@@ -503,7 +503,7 @@ Hochgestellten Text in passender Größe generiert folgender Befehl:
 \end{quote}
 
 \begin{LTXexample}
-le 2\textsuperscript{i\`eme}
+le 2\textsuperscript{e}
 r\'egime
 \end{LTXexample}
 


### PR DESCRIPTION
In French typography, "deuxième" is written 2ᵉ, not 2ⁱᵉᵐᵉ (see: https://fr.wikipedia.org/wiki/Adjectif_numéral_en_français#Abréviation_des_ordinaux, which say: "Deuxième, deuxièmes donnent : 2ᵉ, 2ᵉˢ". You can also consult http://mirrors.ctan.org/macros/latex/contrib/babel-contrib/french/frenchb-doc.pdf on page 7 about the commande \ieme which produce only "e" in superscript).